### PR TITLE
Make inputs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ A Replicated API token (create one at [vendor.replicated.com](https://vendor.rep
 
 A directory containing KOTS manifests, defaults to `./manifests`.
 
+#### release-notes
+
+The release notes for the promoted release, defaults to `GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})`.
+
+#### promote-channel
+
+The channel to promote the release into, defaults to `${GITHUB_REF}`.
+
+#### version
+
+The version number to set, defaults to first 7 characters of the commit SHA.
 
 ### Limiting to specific branches or patterns
 

--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,23 @@ inputs:
     description: 'Directory containing KOTS application manifests'
     required: true
     default: 'manifests'
+  release-notes:
+    description: 'Release notes for the promoted release'
+    required: true
+    default: 'GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})'
+  promote-channel:
+    description: 'Channel to promote the release into'
+    required: true
+    default: '${GITHUB_REF}'
+  version:
+    description: 'Release version'
+    required: true
+    default: '${GITHUB_SHA::7}'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - '/replicated release create --promote=${GITHUB_REF} --ensure-channel --yaml-dir=${{ inputs.yaml-dir }} --release-notes="GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})" --version=${GITHUB_SHA::7}'
+    - '/replicated release create --promote=${{ inputs.promote-channel }} --ensure-channel --yaml-dir=${{ inputs.yaml-dir }} --release-notes=${{ inputs.release-notes }} --version=${{ inputs.version }}'
   env:
     REPLICATED_APP: ${{ inputs.replicated-app }}
     REPLICATED_API_TOKEN: ${{ inputs.replicated-api-token }}


### PR DESCRIPTION
Lets release notes, channel and version be configurable. Defaults remain the same as old values. Fixes #1