### PR TITLE
Quote args in case they contain spaces

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - '/replicated release create --promote=${{ inputs.promote-channel }} --ensure-channel --yaml-dir=${{ inputs.yaml-dir }} --release-notes=${{ inputs.release-notes }} --version=${{ inputs.version }}'
+    - '/replicated release create --promote="${{ inputs.promote-channel }}" --ensure-channel --yaml-dir="${{ inputs.yaml-dir }}" --release-notes="${{ inputs.release-notes }}" --version="${{ inputs.version }}"'
   env:
     REPLICATED_APP: ${{ inputs.replicated-app }}
     REPLICATED_API_TOKEN: ${{ inputs.replicated-api-token }}


### PR DESCRIPTION
Our release notes when publishing this are currently cut off at the first word. Quote all inputs in case they contain spaces so they're evaluated as single arguments.