### PR TITLE
Fix default release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A directory containing KOTS manifests, defaults to `./manifests`.
 
 #### release-notes
 
-The release notes for the promoted release, defaults to `GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})`.
+The release notes for the promoted release, defaults to `GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})`. If your message includes `"` they must be shell-escaped (`\"`).
 
 #### promote-channel
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   release-notes:
     description: 'Release notes for the promoted release'
     required: true
-    default: '"GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"'
+    default: 'GitHub Action release of ${GITHUB_REF} triggered by ${GITHUB_ACTOR}: [${GITHUB_SHA::7}](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})'
   promote-channel:
     description: 'Channel to promote the release into'
     required: true


### PR DESCRIPTION
The default release notes worked around the quoting issue by including quotes in the value explicitly. Removes those quotes so that the default value results in a valid command, and adds a note to the README that if you now use quotes they must be escaped.